### PR TITLE
1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 !/.prettierignore
 !/.vscode
 !/src
+!/lib
 !/test
 !/package.json
 !/azure-pipelines.yml

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,48 @@
+/* eslint-env browser */
+"use strict";
+(function() {
+	function snapshotToJson(node, skipEmpty) {
+		const serialized = {};
+		const isValid = typeof node === "object" && node !== null;
+		if (isValid) {
+			if (node.tagName) {
+				serialized.tagName = node.tagName.toLowerCase();
+			} else if (node.nodeName) {
+				serialized.nodeName = node.nodeName;
+			}
+			if (node.nodeValue) {
+				serialized.nodeValue = node.nodeValue;
+			}
+
+			const attrs = node.attributes;
+			if (attrs) {
+				const l = attrs.length;
+				if (l > 0) {
+					const aggregated = {};
+					for (let i = 0; i < l; i++) {
+						const attr = attrs[i];
+						const skip = skipEmpty && !attr.nodeValue;
+						if (!skip) {
+							aggregated[attr.nodeName] = attr.nodeValue;
+						}
+					}
+					serialized.attributes = aggregated;
+				}
+			}
+
+			const {childNodes} = node;
+			if (childNodes) {
+				const l = childNodes.length;
+				if (l > 0) {
+					const aggregated = new Array(l);
+					for (let i = 0; i < l; i++) {
+						aggregated[i] = snapshotToJson(childNodes[i], skipEmpty);
+					}
+					serialized.childNodes = aggregated;
+				}
+			}
+		}
+		return serialized;
+	}
+	window.snapshotToJson = snapshotToJson;
+})();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "main": "src/snapshot.js",
   "files": [
-    "src"
+    "src",
+    "lib"
   ],
   "scripts": {
     "lint": "eslint ./src/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/snapshot-dom",
-  "version": "1.5.0",
+  "version": "1.6.0-alpha1",
   "description": "Converts a DOM element to a JSON tree",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "express": "4.17.1",
     "jsdom": "15.2.1",
     "mocha": "6.2.2",
-    "prettier": "1.19.1"
+    "prettier": "1.19.1",
+    "puppeteer": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@wildpeaks/eslint-config-commonjs": "8.0.0",
     "eslint": "6.8.0",
+    "express": "4.17.1",
     "jsdom": "15.2.1",
     "mocha": "6.2.2",
     "prettier": "1.19.1"

--- a/test/fixtures/attributes.html
+++ b/test/fixtures/attributes.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><button role="heading" style="color: green">Search</button></body></html>

--- a/test/fixtures/attributes.json
+++ b/test/fixtures/attributes.json
@@ -1,0 +1,18 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "button",
+			"attributes": {
+				"role": "heading",
+				"style": "color: green"
+			},
+			"childNodes": [
+				{
+					"nodeName": "#text",
+					"nodeValue": "Search"
+				}
+			]
+		}
+	]
+}

--- a/test/fixtures/duplicated_attribute_alphabetic_order.html
+++ b/test/fixtures/duplicated_attribute_alphabetic_order.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><div class="AAA" class="ZZZ"></div></body></html>

--- a/test/fixtures/duplicated_attribute_alphabetic_order.json
+++ b/test/fixtures/duplicated_attribute_alphabetic_order.json
@@ -1,0 +1,11 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "div",
+			"attributes": {
+				"class": "AAA"
+			}
+		}
+	]
+}

--- a/test/fixtures/duplicated_attribute_reverse_order.html
+++ b/test/fixtures/duplicated_attribute_reverse_order.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><div class="ZZZ" class="AAA"></div></body></html>

--- a/test/fixtures/duplicated_attribute_reverse_order.json
+++ b/test/fixtures/duplicated_attribute_reverse_order.json
@@ -1,0 +1,11 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "div",
+			"attributes": {
+				"class": "ZZZ"
+			}
+		}
+	]
+}

--- a/test/fixtures/empty_attributes_default_behavior.html
+++ b/test/fixtures/empty_attributes_default_behavior.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><img data-param1 data-param2="" data-param3="  " data-param4="false" data-param5=false /></body></html>

--- a/test/fixtures/empty_attributes_default_behavior.json
+++ b/test/fixtures/empty_attributes_default_behavior.json
@@ -1,0 +1,15 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "img",
+			"attributes": {
+				"data-param1": "",
+				"data-param2": "",
+				"data-param3": "  ",
+				"data-param4": "false",
+				"data-param5": "false"
+			}
+		}
+	]
+}

--- a/test/fixtures/empty_attributes_skip_false.html
+++ b/test/fixtures/empty_attributes_skip_false.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><img data-param1 data-param2="" data-param3="  " data-param4="false" data-param5=false /></body></html>

--- a/test/fixtures/empty_attributes_skip_false.json
+++ b/test/fixtures/empty_attributes_skip_false.json
@@ -1,0 +1,15 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "img",
+			"attributes": {
+				"data-param1": "",
+				"data-param2": "",
+				"data-param3": "  ",
+				"data-param4": "false",
+				"data-param5": "false"
+			}
+		}
+	]
+}

--- a/test/fixtures/empty_attributes_skip_true.html
+++ b/test/fixtures/empty_attributes_skip_true.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><img data-param1 data-param2="" data-param3="  " data-param4="false" data-param5=false /></body></html>

--- a/test/fixtures/empty_attributes_skip_true.json
+++ b/test/fixtures/empty_attributes_skip_true.json
@@ -1,0 +1,13 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "img",
+			"attributes": {
+				"data-param3": "  ",
+				"data-param4": "false",
+				"data-param5": "false"
+			}
+		}
+	]
+}

--- a/test/fixtures/empty_body.html
+++ b/test/fixtures/empty_body.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body></body></html>

--- a/test/fixtures/empty_body.json
+++ b/test/fixtures/empty_body.json
@@ -1,0 +1,3 @@
+{
+	"tagName": "body"
+}

--- a/test/fixtures/nested_elements_in_body.html
+++ b/test/fixtures/nested_elements_in_body.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><div class="outer"><div class="inner"></div><p></p></div></body></html>

--- a/test/fixtures/nested_elements_in_body.json
+++ b/test/fixtures/nested_elements_in_body.json
@@ -1,0 +1,22 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "div",
+			"attributes": {
+				"class": "outer"
+			},
+			"childNodes": [
+				{
+					"tagName": "div",
+					"attributes": {
+						"class": "inner"
+					}
+				},
+				{
+					"tagName": "p"
+				}
+			]
+		}
+	]
+}

--- a/test/fixtures/single_paragraph_in_body.html
+++ b/test/fixtures/single_paragraph_in_body.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><p class="test1"></p></body></html>

--- a/test/fixtures/single_paragraph_in_body.json
+++ b/test/fixtures/single_paragraph_in_body.json
@@ -1,0 +1,11 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "p",
+			"attributes": {
+				"class": "test1"
+			}
+		}
+	]
+}

--- a/test/fixtures/text_fragment.html
+++ b/test/fixtures/text_fragment.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body><p>Hello World</p></body></html>

--- a/test/fixtures/text_fragment.json
+++ b/test/fixtures/text_fragment.json
@@ -1,0 +1,14 @@
+{
+	"tagName": "body",
+	"childNodes": [
+		{
+			"tagName": "p",
+			"childNodes": [
+				{
+					"nodeName": "#text",
+					"nodeValue": "Hello World"
+				}
+			]
+		}
+	]
+}

--- a/test/invalid.spec.js
+++ b/test/invalid.spec.js
@@ -1,0 +1,28 @@
+/* eslint-env node, mocha */
+"use strict";
+const {deepStrictEqual} = require("assert");
+const snapshot = require("..");
+
+describe("Invalid", () => {
+	it("Missing element", () => {
+		deepStrictEqual(snapshot.toJSON(), {});
+	});
+	it("Invalid element (0)", () => {
+		deepStrictEqual(snapshot.toJSON(0), {});
+	});
+	it("Invalid element (1)", () => {
+		deepStrictEqual(snapshot.toJSON(1), {});
+	});
+	it("Invalid element (false)", () => {
+		deepStrictEqual(snapshot.toJSON(false), {});
+	});
+	it("Invalid element (true)", () => {
+		deepStrictEqual(snapshot.toJSON(true), {});
+	});
+	it("Invalid element (null)", () => {
+		deepStrictEqual(snapshot.toJSON(null), {});
+	});
+	it("Invalid element (undefined)", () => {
+		deepStrictEqual(snapshot.toJSON(undefined), {});
+	});
+});

--- a/test/jsdom.spec.js
+++ b/test/jsdom.spec.js
@@ -7,30 +7,6 @@ const {JSDOM} = require("jsdom");
 const snapshot = require("..");
 const fixturesFolder = join(__dirname, "fixtures");
 
-describe("Invalid", () => {
-	it("Missing element", () => {
-		deepStrictEqual(snapshot.toJSON(), {});
-	});
-	it("Invalid element (0)", () => {
-		deepStrictEqual(snapshot.toJSON(0), {});
-	});
-	it("Invalid element (1)", () => {
-		deepStrictEqual(snapshot.toJSON(1), {});
-	});
-	it("Invalid element (false)", () => {
-		deepStrictEqual(snapshot.toJSON(false), {});
-	});
-	it("Invalid element (true)", () => {
-		deepStrictEqual(snapshot.toJSON(true), {});
-	});
-	it("Invalid element (null)", () => {
-		deepStrictEqual(snapshot.toJSON(null), {});
-	});
-	it("Invalid element (undefined)", () => {
-		deepStrictEqual(snapshot.toJSON(undefined), {});
-	});
-});
-
 function testFixture(id, skip) {
 	it(`Fixture: ${id}`, () => {
 		const html = readFileSync(join(fixturesFolder, `${id}.html`), "utf8");
@@ -41,7 +17,7 @@ function testFixture(id, skip) {
 	});
 }
 
-describe("JSDOM: Valid", () => {
+describe("JSDOM", () => {
 	it("Single paragraph in detached element", () => {
 		const dom = new JSDOM("<!DOCTYPE html><html><head></head><body></body></html>");
 		const {document} = dom.window;

--- a/test/jsdom.spec.js
+++ b/test/jsdom.spec.js
@@ -5,7 +5,7 @@ const {deepStrictEqual} = require("assert");
 const {JSDOM} = require("jsdom");
 const snapshot = require("..");
 
-describe("toJSON", () => {
+describe("JSDOM Tests", () => {
 	// Reset DOM
 	before(() => {
 		const dom = new JSDOM("<!DOCTYPE html><html><head></head><body></body></html>");

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -1,0 +1,75 @@
+/* eslint-env node, mocha, browser */
+/* eslint-disable prefer-arrow-callback */
+"use strict";
+const {deepStrictEqual} = require("assert");
+const {readFileSync} = require("fs");
+const {join} = require("path");
+const express = require("express");
+const puppeteer = require("puppeteer");
+
+const fixturesFolder = join(__dirname, "fixtures");
+const script = join(__dirname, "../lib/browser.js");
+
+const port = 8888;
+const baseurl = `http://localhost:${port}/`;
+let app;
+let server;
+
+function sleep(duration) {
+	return new Promise(resolve => {
+		setTimeout(() => {
+			resolve();
+		}, duration);
+	});
+}
+
+before(function() {
+	return new Promise(resolve => {
+		app = express();
+		app.use(express.static(fixturesFolder));
+		server = app.listen(port, () => {
+			resolve();
+		});
+	});
+});
+after(function() {
+	return new Promise(resolve => {
+		server.close(() => {
+			resolve();
+		});
+	});
+});
+
+function testFixture(id, skip) {
+	it(`Fixture: ${id}`, /* @this */ async function() {
+		this.slow(15000);
+		this.timeout(15000);
+		let actualNodes;
+		const browser = await puppeteer.launch();
+		try {
+			const page = await browser.newPage();
+			await page.goto(`${baseurl}${id}.html`, {waitUntil: "load"});
+			await sleep(300);
+			await page.addScriptTag({path: script});
+			await sleep(300);
+			actualNodes = await page.evaluate(opt => window.snapshotToJson(document.body, opt), skip);
+		} finally {
+			await browser.close();
+		}
+		const expectedNodes = JSON.parse(readFileSync(join(fixturesFolder, `${id}.json`), "utf8"));
+		deepStrictEqual(actualNodes, expectedNodes);
+	});
+}
+
+describe("Puppeteer", () => {
+	testFixture("empty_body");
+	testFixture("single_paragraph_in_body");
+	testFixture("nested_elements_in_body");
+	testFixture("text_fragment");
+	testFixture("attributes");
+	testFixture("duplicated_attribute_alphabetic_order");
+	testFixture("duplicated_attribute_reverse_order");
+	testFixture("empty_attributes_default_behavior");
+	testFixture("empty_attributes_skip_false", false);
+	testFixture("empty_attributes_skip_true", true);
+});


### PR DESCRIPTION
Adds an IIFE version (in `lib/browser.js`) that can be used in headless tests, for example:

````ts
const puppeteer = require("puppeteer");
const script = require.resolve("@wildpeaks/snapshot-dom/lib/browser.js");

const browser = await puppeteer.launch();
try {
  const page = await browser.newPage();
  await page.goto("http://localhost:8000/", {waitUntil: "load"});
  await page.addScriptTag({path: script});
  const snapshot = await page.evaluate(() => window.snapshotToJson(document.body));
  console.log(snapshot);
} finally {
  await browser.close();
}
````