### PR TITLE
Feature: options as Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ document.body.innerHTML = '<img param1 param2="" param3="hello" />;
 
 // Without skipping
 assert.deepStrictEqual(
-	snapshot.toJSON(document.body, false),
+	snapshot.toJSON(document.body, {skipEmptyValue: false}),
 	{
 		tagName: 'body',
 		childNodes: [
@@ -75,7 +75,7 @@ assert.deepStrictEqual(
 
 // With skipping
 assert.deepStrictEqual(
-	snapshot.toJSON(document.body, true),
+	snapshot.toJSON(document.body, {skipEmptyValue: true}),
 	{
 		tagName: 'body',
 		childNodes: [
@@ -90,5 +90,5 @@ assert.deepStrictEqual(
 );
 ````
 
-Note that strings containing only whitespace are not empty.
+Note that strings containing only whitespace characters are not empty values.
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,7 +1,7 @@
 /* eslint-env browser */
 "use strict";
 (function() {
-	function snapshotToJson(node, skipEmpty) {
+	function snapshotToJson(node, options = {}) {
 		const serialized = {};
 		const isValid = typeof node === "object" && node !== null;
 		if (isValid) {
@@ -21,7 +21,7 @@
 					const aggregated = {};
 					for (let i = 0; i < l; i++) {
 						const attr = attrs[i];
-						const skip = skipEmpty && !attr.nodeValue;
+						const skip = options.skipEmptyValue && !attr.nodeValue;
 						if (!skip) {
 							aggregated[attr.nodeName] = attr.nodeValue;
 						}
@@ -36,7 +36,7 @@
 				if (l > 0) {
 					const aggregated = new Array(l);
 					for (let i = 0; i < l; i++) {
-						aggregated[i] = snapshotToJson(childNodes[i], skipEmpty);
+						aggregated[i] = snapshotToJson(childNodes[i], options);
 					}
 					serialized.childNodes = aggregated;
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/snapshot-dom",
-  "version": "1.6.0",
+  "version": "2.0.0-rc1",
   "description": "Converts a DOM element to a JSON tree",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -1,12 +1,17 @@
 "use strict";
 
 /**
+ * @typedef {Object} Options
+ * @property {Boolean} skipEmptyValue - Skips node values that evaluate to false (undefined and zero-length strings)
+ */
+
+/**
  * Convert a DOM element to a simpler JSON tree.
  * @param  {Node} node
- * @param  {Boolean} skipEmpty Skips node values that evaluate to false (undefined and empty strings)
+ * @param  {Options} options
  * @return {Object}
  */
-function toJSON(node, skipEmpty) {
+function toJSON(node, options = {}) {
 	const serialized = {};
 	const isValid = typeof node === "object" && node !== null;
 	if (isValid) {
@@ -28,7 +33,7 @@ function toJSON(node, skipEmpty) {
 				const aggregated = {};
 				for (let i = 0; i < l; i++) {
 					const attr = attrs[i];
-					const skip = skipEmpty && !attr.nodeValue;
+					const skip = options.skipEmptyValue && !attr.nodeValue;
 					if (!skip) {
 						aggregated[attr.nodeName] = attr.nodeValue;
 					}
@@ -43,7 +48,7 @@ function toJSON(node, skipEmpty) {
 			if (l > 0) {
 				const aggregated = new Array(l);
 				for (let i = 0; i < l; i++) {
-					aggregated[i] = toJSON(childNodes[i], skipEmpty);
+					aggregated[i] = toJSON(childNodes[i], options);
 				}
 				serialized.childNodes = aggregated;
 			}

--- a/test/jsdom.spec.js
+++ b/test/jsdom.spec.js
@@ -7,12 +7,12 @@ const {JSDOM} = require("jsdom");
 const snapshot = require("..");
 const fixturesFolder = join(__dirname, "fixtures");
 
-function testFixture(id, skip) {
+function testFixture(id, options) {
 	it(`Fixture: ${id}`, () => {
 		const html = readFileSync(join(fixturesFolder, `${id}.html`), "utf8");
 		const expected = JSON.parse(readFileSync(join(fixturesFolder, `${id}.json`), "utf8"));
 		const dom = new JSDOM(html);
-		const actual = snapshot.toJSON(dom.window.document.body, skip);
+		const actual = snapshot.toJSON(dom.window.document.body, options);
 		deepStrictEqual(actual, expected);
 	});
 }
@@ -38,6 +38,6 @@ describe("JSDOM", () => {
 	testFixture("duplicated_attribute_alphabetic_order");
 	testFixture("duplicated_attribute_reverse_order");
 	testFixture("empty_attributes_default_behavior");
-	testFixture("empty_attributes_skip_false", false);
-	testFixture("empty_attributes_skip_true", true);
+	testFixture("empty_attributes_skip_false", {skipEmptyValue: false});
+	testFixture("empty_attributes_skip_true", {skipEmptyValue: true});
 });

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -70,6 +70,6 @@ describe("Puppeteer", () => {
 	testFixture("duplicated_attribute_alphabetic_order");
 	testFixture("duplicated_attribute_reverse_order");
 	testFixture("empty_attributes_default_behavior");
-	testFixture("empty_attributes_skip_false", false);
-	testFixture("empty_attributes_skip_true", true);
+	testFixture("empty_attributes_skip_false", {skipEmptyValue: false});
+	testFixture("empty_attributes_skip_true", {skipEmptyValue: true});
 });


### PR DESCRIPTION
There will be a second option soon, so it's time to switch to a wrapping Object instead of passing the value of the one option directly.

Example:
````js
// Before
toJSON(document.body, true);

// Now
toJSON(document.body, {skipEmptyValue: true});
````
