### PR TITLE
Package updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@wildpeaks/eslint-config-commonjs": "8.4.0",
     "eslint": "6.8.0",
     "jsdom": "16.2.1",
-    "mocha": "7.1.0",
+    "mocha": "7.1.1",
     "prettier": "1.19.1",
     "puppeteer": "2.1.1",
     "rimraf": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,16 @@
     "build": "mocha src/build.js",
     "test": "mocha test/*.spec.js"
   },
+  "dependencies": {
+    "mocha": "7.1.1",
+    "rimraf": "3.0.2",
+    "terser": "4.6.7"
+  },
   "devDependencies": {
     "@wildpeaks/eslint-config-commonjs": "8.4.0",
     "eslint": "6.8.0",
     "jsdom": "16.2.1",
-    "mocha": "7.1.1",
     "prettier": "1.19.1",
-    "puppeteer": "2.1.1",
-    "rimraf": "3.0.2",
-    "terser": "4.6.7"
+    "puppeteer": "2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "prettier": "1.19.1",
     "puppeteer": "2.1.1",
     "rimraf": "3.0.2",
-    "terser": "4.6.6"
+    "terser": "4.6.7"
   }
 }


### PR DESCRIPTION
Updated `mocha` and `terser`.

Promoted `mocha`, `rimraf`, `terser` to toplevel dependencies.