### PR TITLE
chore: set EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,14 @@
 * -text
 
-.editorconfig   text
-.gitattributes  text
-.gitignore      text
-LICENSE         text
-README          text
-*.txt           text
-*.md            text
-*.map           text
-*.js            text
-*.json          text
-*.html          text
-*.yml           text
+.editorconfig   text eol=lf
+.gitattributes  text eol=lf
+.gitignore      text eol=lf
+LICENSE         text eol=lf
+README          text eol=lf
+*.txt           text eol=lf
+*.md            text eol=lf
+*.map           text eol=lf
+*.js            text eol=lf
+*.json          text eol=lf
+*.html          text eol=lf
+*.yml           text eol=lf


### PR DESCRIPTION
Something changed in the past 48h that is making my computer ignore `autocrlf false`, so I'm setting an explicit EOL for text formats even though it's redundant with `.editorconfig` and `autocrlf`.