### PR TITLE
Update node-version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [14.x, 15.x]
+        node: [16.x, 17.x]
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Bumps to 16.x & 17.x to match the current LTS/Latest Node versions.